### PR TITLE
Try to rewrite/redefine the code

### DIFF
--- a/demo/run_server.go
+++ b/demo/run_server.go
@@ -12,7 +12,7 @@ import (
 
 func runServer() {
 
-	ws := arca.JSONRPCServerWS{}
+	ws := arca.JSONRPCExtensionWS{}
 
 	goods := grid.Grid{}
 	users := grid.Grid{}

--- a/gt
+++ b/gt
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+while true
+do
+  inotifywait -qq -r -e create,close_write,modify,move,delete ./ && date --iso-8601=ns && go test -test.timeout 1s
+done

--- a/handle.go
+++ b/handle.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Handle whatever
-func (s *JSONRPCServerWS) Handle(
+func (s *JSONRPCExtensionWS) Handle(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {

--- a/handle_test.go
+++ b/handle_test.go
@@ -3,20 +3,22 @@ package arca
 import (
 	"errors"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/gorilla/websocket"
 )
 
 func Test_Handle_upgradeConnection_OK(t *testing.T) {
-	t.Log("Test Handle function")
+	t.Log("Test Handle upgradeConnection function OK")
 
 	s := *createServer(t)
 	s.transport.closeConnection = func(conn *websocket.Conn) error {
 		return nil
 	}
 
-	done := make(chan bool)
+	w := sync.WaitGroup{}
+	w.Add(1)
 	expectedDone := errors.New("EOF")
 	expectedResult := "my result"
 	var actualResult string
@@ -43,7 +45,7 @@ func Test_Handle_upgradeConnection_OK(t *testing.T) {
 
 	s.transport.writeJSON = func(_ *websocket.Conn, response *JSONRPCresponse) error {
 		actualResult = response.Result.(string)
-		done <- true
+		w.Done()
 		return nil
 	}
 
@@ -61,7 +63,7 @@ func Test_Handle_upgradeConnection_OK(t *testing.T) {
 	}
 
 	go s.Handle(nil, nil)
-	<-done
+	w.Wait()
 
 	if actualResult != expectedResult {
 		t.Error("expected result differs from actual result")
@@ -69,7 +71,7 @@ func Test_Handle_upgradeConnection_OK(t *testing.T) {
 }
 
 func Test_Handle_upgradeConnection_error(t *testing.T) {
-	t.Log("Test Handle function")
+	t.Log("Test Handle upgradeConnection function ERROR")
 
 	s := *createServer(t)
 	s.transport.closeConnection = func(conn *websocket.Conn) error {

--- a/init.go
+++ b/init.go
@@ -2,7 +2,6 @@ package arca
 
 import (
 	"net/http"
-	"sync"
 
 	"github.com/gorilla/websocket"
 )
@@ -13,9 +12,12 @@ var upgrader = websocket.Upgrader{
 }
 
 // Init sets up the
-func (s *JSONRPCServerWS) Init() {
-	s.connections = sync.Map{}
-	s.tick = make(chan bool)
+func (s *JSONRPCExtensionWS) Init() {
+	if s.tick == nil {
+		s.tick = make(chan bool)
+		go (func() { s.tick <- true })()
+	}
+
 	if s.handlers == nil {
 		s.handlers = map[string]map[string]*JSONRequestHandler{}
 	}

--- a/listenAndResponse.go
+++ b/listenAndResponse.go
@@ -1,8 +1,10 @@
 package arca
 
-import "github.com/gorilla/websocket"
+import (
+	"github.com/gorilla/websocket"
+)
 
-func (s *JSONRPCServerWS) listenAndResponse(
+func (s *JSONRPCExtensionWS) listenAndResponse(
 	conn *websocket.Conn,
 ) error {
 	s.connections.Store(conn, make(chan *JSONRPCresponse))

--- a/listenAndResponse_test.go
+++ b/listenAndResponse_test.go
@@ -2,6 +2,8 @@ package arca
 
 import (
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/gorilla/websocket"
@@ -125,6 +127,8 @@ func Test_listenAndResponse_readJSON_matchHandler_OK(t *testing.T) {
 	t.Log("Test listenAndResponse readJSON matchHandler OK")
 
 	s := *createServer(t)
+	w := sync.WaitGroup{}
+	w.Add(1)
 	s.transport.closeConnection = func(conn *websocket.Conn) error {
 		return nil
 	}
@@ -149,6 +153,7 @@ func Test_listenAndResponse_readJSON_matchHandler_OK(t *testing.T) {
 
 	s.transport.writeJSON = func(_ *websocket.Conn, response *JSONRPCresponse) error {
 		actualResult = response.Result.(string)
+		w.Done()
 		return nil
 	}
 
@@ -166,16 +171,109 @@ func Test_listenAndResponse_readJSON_matchHandler_OK(t *testing.T) {
 	}
 
 	err := s.listenAndResponse(conn)
-
 	_, ok := s.connections.Load(conn)
+
+	w.Wait()
+
 	if ok {
 		t.Error("conn souldn't be present in connections")
+	}
+	if actualResult != expectedResult {
+		t.Errorf("expected '%s' result differs from actual '%s' result",
+			expectedResult, actualResult)
 	}
 	if err != expectedDone {
 		t.Error("unexpected done")
 	}
-	if actualResult != expectedResult {
+}
+
+func Test_listenAndResponse_readJSON_matchHandler_3x_responses_OK(t *testing.T) {
+	t.Log("Test listenAndResponse readJSON matchHandler and send 3 responses OK")
+
+	s := *createServer(t)
+	w := sync.WaitGroup{}
+	w.Add(3)
+	s.transport.closeConnection = func(conn *websocket.Conn) error {
+		return nil
+	}
+
+	conn := &websocket.Conn{}
+	expectedDone := errors.New("EOF")
+	expectedResult1 := "my result 1"
+	expectedResult2 := "my result 2"
+	expectedResult3 := "my result 3"
+	var actualResult1 string
+	var actualResult2 string
+	var actualResult3 string
+
+	i := 0
+
+	s.transport.readJSON = func(_ *websocket.Conn, request *JSONRPCrequest) error {
+		i++
+		if i > 3 {
+			return expectedDone
+		}
+		var context interface{} = map[string]interface{}{"source": "whatever"}
+		request.Context = context
+		request.Method = "method"
+		request.ID = fmt.Sprintf("my-id-%v", i)
+		request.Params = i
+		return nil
+	}
+
+	s.transport.writeJSON = func(_ *websocket.Conn, response *JSONRPCresponse) error {
+		if response.ID == "my-id-1" {
+			actualResult1 = response.Result.(string)
+		} else if response.ID == "my-id-2" {
+			actualResult2 = response.Result.(string)
+		} else if response.ID == "my-id-3" {
+			actualResult3 = response.Result.(string)
+		}
+		w.Done()
+		return nil
+	}
+
+	var handler JSONRequestHandler = func(
+		requestParams *interface{},
+		_ *interface{},
+	) (interface{}, error) {
+		var result interface{}
+		if (*requestParams).(int) == 1 {
+			result = expectedResult1
+		} else if (*requestParams).(int) == 2 {
+			result = expectedResult2
+		} else if (*requestParams).(int) == 3 {
+			result = expectedResult3
+		}
+		return result, nil
+	}
+	s.handlers = map[string]map[string]*JSONRequestHandler{
+		"whatever": map[string]*JSONRequestHandler{
+			"method": &handler,
+		},
+	}
+
+	err := s.listenAndResponse(conn)
+	_, ok := s.connections.Load(conn)
+
+	w.Wait()
+
+	if ok {
+		t.Error("conn souldn't be present in connections")
+	}
+	if actualResult1 != expectedResult1 {
 		t.Errorf("expected '%s' result differs from actual '%s' result",
-			expectedDone, actualResult)
+			expectedResult1, actualResult1)
+	}
+	if actualResult2 != expectedResult2 {
+		t.Errorf("expected '%s' result differs from actual '%s' result",
+			expectedResult2, actualResult2)
+	}
+	if actualResult3 != expectedResult3 {
+		t.Errorf("expected '%s' result differs from actual '%s' result",
+			expectedResult3, actualResult3)
+	}
+	if err != expectedDone {
+		t.Error("unexpected done")
 	}
 }

--- a/matchHandler.go
+++ b/matchHandler.go
@@ -2,7 +2,7 @@ package arca
 
 import "fmt"
 
-func (s *JSONRPCServerWS) matchHandler(
+func (s *JSONRPCExtensionWS) matchHandler(
 	request *JSONRPCrequest,
 ) (*JSONRequestHandler, error) {
 	method := request.Method

--- a/registerMethod.go
+++ b/registerMethod.go
@@ -3,7 +3,7 @@ package arca
 import "fmt"
 
 // RegisterMethod whatever
-func (s *JSONRPCServerWS) RegisterMethod(
+func (s *JSONRPCExtensionWS) RegisterMethod(
 	source string,
 	method string,
 	handler *JSONRequestHandler,

--- a/registerMethod_test.go
+++ b/registerMethod_test.go
@@ -55,7 +55,7 @@ func Test_registerMethod_without_method(t *testing.T) {
 func Test_registerMethod_no_Init(t *testing.T) {
 	t.Log("RegisterMethod success without calling Init")
 
-	s := JSONRPCServerWS{}
+	s := JSONRPCExtensionWS{}
 	var handler JSONRequestHandler = func(
 		requestParams *interface{},
 		context *interface{},

--- a/stuff_test.go
+++ b/stuff_test.go
@@ -337,32 +337,3 @@ func Test_sendResponse_2conns_3responses_without_ID(t *testing.T) {
 	s.closeConnection(conn1)
 	s.closeConnection(conn2)
 }
-
-/*
-func Test_call_Init_from_Handle(t *testing.T) {
-	t.Log("Test call Init from Handle")
-
-	s := JSONRPCExtensionWS{}
-	s.transport.closeConnection = func(conn *websocket.Conn) error {
-		return nil
-	}
-
-	expectedDone := errors.New("EOF")
-	done := make(chan bool)
-
-	s.transport.upgradeConnection = func(
-		http.ResponseWriter,
-		*http.Request,
-	) (*websocket.Conn, error) {
-		done <- true
-		return nil, expectedDone
-	}
-
-	go s.Handle(nil, nil)
-	<-done
-
-	if s.tick == nil {
-		t.Error("Init() should initiate tick channel")
-	}
-}
-*/

--- a/stuff_test.go
+++ b/stuff_test.go
@@ -1,20 +1,22 @@
 package arca
 
 import (
-	"errors"
-	"net/http"
 	"sync"
 	"testing"
 
 	"github.com/gorilla/websocket"
 )
 
-func createServer(t *testing.T) *JSONRPCServerWS {
-	s := JSONRPCServerWS{}
+func createServer(t *testing.T) *JSONRPCExtensionWS {
+	s := JSONRPCExtensionWS{}
 	s.Init()
 
 	if s.tick == nil {
-		t.Error("Init() should initiate tick channel")
+		t.Error("Init() should initiate the tick")
+	}
+
+	if s.handlers == nil {
+		t.Error("Init() should initiate the handler map")
 	}
 
 	return &s
@@ -23,15 +25,20 @@ func createServer(t *testing.T) *JSONRPCServerWS {
 func Test_readJSON_redefinition(t *testing.T) {
 	t.Log("Test readJSON redefinition")
 
+	// setup
 	s := *createServer(t)
-	readJSONCalled := false
+	readJSONCalled := false // flag
+
+	// redefine the readJSON function
 	s.transport.readJSON = func(*websocket.Conn, *JSONRPCrequest) error {
-		readJSONCalled = true
+		readJSONCalled = true // expecting this flag to be modified
 		return nil
 	}
 
+	// excercise
 	s.readJSON(nil, nil)
 
+	// verify
 	if !readJSONCalled {
 		t.Error("readJSON call failed")
 	}
@@ -40,17 +47,23 @@ func Test_readJSON_redefinition(t *testing.T) {
 func Test_closeConnection_redefinition(t *testing.T) {
 	t.Log("Test closeConnection redefinition")
 
+	// setup
 	s := *createServer(t)
-	closeConnectionCalled := false
+	closeConnectionCalled := false // flag
+
+	// redefine the readJSON function
 	s.transport.closeConnection = func(*websocket.Conn) error {
-		closeConnectionCalled = true
+		closeConnectionCalled = true // expecting this flag to be modified
 		return nil
 	}
 
 	conn := &websocket.Conn{}
 	s.connections.Store(conn, make(chan *JSONRPCresponse))
+
+	// excercise
 	s.closeConnection(conn)
 
+	// verify
 	if !closeConnectionCalled {
 		t.Error("closeConnection call failed")
 	}
@@ -64,6 +77,7 @@ func Test_closeConnection_redefinition(t *testing.T) {
 func Test_sendResponse_with_ID(t *testing.T) {
 	t.Log("Test sendResponse with ID")
 
+	// setup
 	s := *createServer(t)
 	s.transport.closeConnection = func(conn *websocket.Conn) error {
 		return nil
@@ -78,23 +92,96 @@ func Test_sendResponse_with_ID(t *testing.T) {
 	request.ID = "an-id"
 
 	s.connections.Store(conn, make(chan *JSONRPCresponse))
-	go s.sendResponse(conn, &request, &expectedResult)
-	connChan, _ := s.connections.Load(conn)
-	response := <-connChan.(chan *JSONRPCresponse)
-	actualResult := response.Result
 
-	if actualResult.(string) != expectedResult.(string) {
-		t.Error("expected result differs from actual result")
+	// excercise
+	go s.sendResponse(conn, &request, &expectedResult)
+
+	// verify
+	connChan, ok := s.connections.Load(conn)
+	if ok {
+		response := <-connChan.(chan *JSONRPCresponse)
+		actualResult := response.Result
+
+		// verify
+		if actualResult.(string) != expectedResult.(string) {
+			t.Error("expected result differs from actual result")
+		}
+	} else {
+		t.Error("unexpected error when loading the response's channel")
 	}
 
+	// tear-down
+	s.closeConnection(conn)
+}
+
+func Test_sendResponse_3_different_responses_with_ID(t *testing.T) {
+	t.Log("Test sendResponse 3 different responses with ID")
+
+	// setup
+	s := *createServer(t)
+	s.transport.closeConnection = func(conn *websocket.Conn) error {
+		return nil
+	}
+
+	conn := &websocket.Conn{}
+	var expectedResult1 interface{} = "expected result 1"
+	request1 := JSONRPCrequest{}
+	request1.Method = "method"
+	request1.ID = "an-id 1"
+
+	var expectedResult2 interface{} = "expected result 2"
+	request2 := JSONRPCrequest{}
+	request2.Method = "method"
+	request2.ID = "an-id 2"
+
+	var expectedResult3 interface{} = "expected result 3"
+	request3 := JSONRPCrequest{}
+	request3.Method = "method"
+	request3.ID = "an-id 3"
+
+	s.connections.Store(conn, make(chan *JSONRPCresponse))
+
+	// excercise
 	go (func() {
-		s.closeConnection(conn)
+		s.sendResponse(conn, &request1, &expectedResult1)
+		s.sendResponse(conn, &request2, &expectedResult2)
+		s.sendResponse(conn, &request3, &expectedResult3)
 	})()
+
+	// verify
+	connChan, ok := s.connections.Load(conn)
+	if ok {
+		response := <-connChan.(chan *JSONRPCresponse)
+		actualResult1 := response.Result
+
+		response = <-connChan.(chan *JSONRPCresponse)
+		actualResult2 := response.Result
+
+		response = <-connChan.(chan *JSONRPCresponse)
+		actualResult3 := response.Result
+
+		// verify
+		if actualResult1.(string) != expectedResult1.(string) {
+			t.Error("expected result differs from actual result")
+		}
+		if actualResult2.(string) != expectedResult2.(string) {
+			t.Error("expected result differs from actual result")
+		}
+		if actualResult3.(string) != expectedResult3.(string) {
+			t.Error("expected result differs from actual result")
+		}
+	} else {
+		t.Error("unexpected error when loading the response's channel")
+	}
+
+	// tear-down
+	s.closeConnection(conn)
 }
 
 func Test_sendResponse_without_ID(t *testing.T) {
-	t.Log("Test sendResponse with ID")
+	t.Log("Test sendResponse without ID")
 
+	// setup
 	s := *createServer(t)
 	s.transport.closeConnection = func(conn *websocket.Conn) error {
 		return nil
@@ -106,53 +193,156 @@ func Test_sendResponse_without_ID(t *testing.T) {
 	conn1 := &websocket.Conn{}
 	conn2 := &websocket.Conn{}
 
-	var expectedResult interface{} = "expected result"
-
-	request := JSONRPCrequest{}
-	request.Method = "method"
-	request.ID = ""
+	var expectedResult1 interface{} = "expected result 1"
+	request1 := JSONRPCrequest{}
+	request1.Method = "method"
+	request1.ID = ""
 
 	s.connections.Store(conn1, make(chan *JSONRPCresponse))
 	s.connections.Store(conn2, make(chan *JSONRPCresponse))
 
-	go s.sendResponse(nil, &request, &expectedResult)
+	go s.sendResponse(nil, &request1, &expectedResult1)
 
-	var response1 *JSONRPCresponse
-	var actualResult1 interface{}
 	go (func() {
-		connChan, _ := s.connections.Load(conn1)
-		response1 = <-connChan.(chan *JSONRPCresponse)
-		actualResult1 = response1.Result
+		connChan, ok := s.connections.Load(conn1)
+		if ok {
+			response := <-connChan.(chan *JSONRPCresponse)
+			actualResult1 := response.Result
+
+			if actualResult1.(string) != expectedResult1.(string) {
+				t.Error("expected result differs from actual result")
+			}
+		} else {
+			t.Error("unexpected error when loading the response's channel")
+		}
 		wg.Done()
 	})()
 
-	var response2 *JSONRPCresponse
-	var actualResult2 interface{}
 	go (func() {
-		connChan, _ := s.connections.Load(conn2)
-		response2 = <-connChan.(chan *JSONRPCresponse)
-		actualResult2 = response2.Result
+		connChan, ok := s.connections.Load(conn2)
+		if ok {
+			response := <-connChan.(chan *JSONRPCresponse)
+			actualResult1 := response.Result
+
+			if actualResult1.(string) != expectedResult1.(string) {
+				t.Error("expected result differs from actual result")
+			}
+		} else {
+			t.Error("unexpected error when loading the response's channel")
+		}
 		wg.Done()
 	})()
 	wg.Wait()
 
-	if actualResult1.(string) != expectedResult.(string) {
-		t.Error("expected result differs from actual result")
-	}
-	if actualResult2.(string) != expectedResult.(string) {
-		t.Error("expected result differs from actual result")
-	}
-
-	go (func() {
-		s.closeConnection(conn1)
-		s.closeConnection(conn2)
-	})()
+	// tear-down
+	s.closeConnection(conn1)
+	s.closeConnection(conn2)
 }
 
+func Test_sendResponse_2conns_3responses_without_ID(t *testing.T) {
+	t.Log("Test sendResponse without ID")
+
+	// setup
+	s := *createServer(t)
+	s.transport.closeConnection = func(conn *websocket.Conn) error {
+		return nil
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	conn1 := &websocket.Conn{}
+	conn2 := &websocket.Conn{}
+
+	var expectedResult1 interface{} = "expected result 1"
+	request1 := JSONRPCrequest{}
+	request1.Method = "method"
+	request1.ID = ""
+
+	var expectedResult2 interface{} = "expected result 2"
+	request2 := JSONRPCrequest{}
+	request2.Method = "method"
+	request2.ID = ""
+
+	var expectedResult3 interface{} = "expected result 3"
+	request3 := JSONRPCrequest{}
+	request3.Method = "method"
+	request3.ID = ""
+
+	s.connections.Store(conn1, make(chan *JSONRPCresponse))
+	s.connections.Store(conn2, make(chan *JSONRPCresponse))
+
+	go (func() {
+		s.sendResponse(nil, &request1, &expectedResult1)
+		s.sendResponse(nil, &request2, &expectedResult2)
+		s.sendResponse(nil, &request3, &expectedResult3)
+	})()
+
+	go (func() {
+		connChan, ok := s.connections.Load(conn1)
+		if ok {
+			response := <-connChan.(chan *JSONRPCresponse)
+			actualResult1 := response.Result
+
+			response = <-connChan.(chan *JSONRPCresponse)
+			actualResult2 := response.Result
+
+			response = <-connChan.(chan *JSONRPCresponse)
+			actualResult3 := response.Result
+
+			if actualResult1.(string) != expectedResult1.(string) {
+				t.Error("expected result differs from actual result")
+			}
+			if actualResult2.(string) != expectedResult2.(string) {
+				t.Error("expected result differs from actual result")
+			}
+			if actualResult3.(string) != expectedResult3.(string) {
+				t.Error("expected result differs from actual result")
+			}
+		} else {
+			t.Error("unexpected error when loading the response's channel")
+		}
+		wg.Done()
+	})()
+
+	go (func() {
+		connChan, ok := s.connections.Load(conn2)
+		if ok {
+			response := <-connChan.(chan *JSONRPCresponse)
+			actualResult1 := response.Result
+
+			response = <-connChan.(chan *JSONRPCresponse)
+			actualResult2 := response.Result
+
+			response = <-connChan.(chan *JSONRPCresponse)
+			actualResult3 := response.Result
+
+			if actualResult1.(string) != expectedResult1.(string) {
+				t.Error("expected result differs from actual result")
+			}
+			if actualResult2.(string) != expectedResult2.(string) {
+				t.Error("expected result differs from actual result")
+			}
+			if actualResult3.(string) != expectedResult3.(string) {
+				t.Error("expected result differs from actual result")
+			}
+		} else {
+			t.Error("unexpected error when loading the response's channel")
+		}
+		wg.Done()
+	})()
+	wg.Wait()
+
+	// tear-down
+	s.closeConnection(conn1)
+	s.closeConnection(conn2)
+}
+
+/*
 func Test_call_Init_from_Handle(t *testing.T) {
 	t.Log("Test call Init from Handle")
 
-	s := JSONRPCServerWS{}
+	s := JSONRPCExtensionWS{}
 	s.transport.closeConnection = func(conn *websocket.Conn) error {
 		return nil
 	}
@@ -175,3 +365,4 @@ func Test_call_Init_from_Handle(t *testing.T) {
 		t.Error("Init() should initiate tick channel")
 	}
 }
+*/

--- a/tickResponse_test.go
+++ b/tickResponse_test.go
@@ -11,14 +11,78 @@ func Test_writeJSON_redefinition(t *testing.T) {
 	t.Log("Test writeJSON redefinition")
 
 	s := *createServer(t)
+	w := sync.WaitGroup{}
+	w.Add(1)
 	writeJSONCalled := false
 	s.transport.writeJSON = func(*websocket.Conn, *JSONRPCresponse) error {
 		writeJSONCalled = true
+		w.Done()
 		return nil
 	}
 
 	go s.writeJSON(nil, nil)
-	<-s.tick
+	w.Wait()
+
+	if !writeJSONCalled {
+		t.Error("writeJSON call failed")
+	}
+
+}
+
+func Test_writeJSON_3x_responses(t *testing.T) {
+	t.Log("Test writeJSON sending 3 responses")
+
+	s := *createServer(t)
+	w := sync.WaitGroup{}
+	w.Add(3)
+
+	var expectedResult1 interface{} = "expected result 1"
+	response1 := JSONRPCresponse{}
+	response1.Method = "method"
+	response1.ID = ""
+	response1.Result = expectedResult1
+
+	var expectedResult2 interface{} = "expected result 2"
+	response2 := JSONRPCresponse{}
+	response2.Method = "method"
+	response2.ID = ""
+	response2.Result = expectedResult2
+
+	var expectedResult3 interface{} = "expected result 3"
+	response3 := JSONRPCresponse{}
+	response3.Method = "method"
+	response3.ID = ""
+	response3.Result = expectedResult3
+
+	writeJSONCalled := false
+	i := 0
+	s.transport.writeJSON = func(_ *websocket.Conn, response *JSONRPCresponse) error {
+		i++
+		writeJSONCalled = true
+		actualResponse := (*response).Result
+		if i == 1 {
+			if actualResponse.(string) != expectedResult1.(string) {
+				t.Error("expected result differs from actual result")
+			}
+		} else if i == 2 {
+			if actualResponse.(string) != expectedResult2.(string) {
+				t.Error("expected result differs from actual result")
+			}
+		} else if i == 3 {
+			if actualResponse.(string) != expectedResult3.(string) {
+				t.Error("expected result differs from actual result")
+			}
+		}
+		w.Done()
+		return nil
+	}
+
+	go (func() {
+		s.writeJSON(nil, &response1)
+		s.writeJSON(nil, &response2)
+		s.writeJSON(nil, &response3)
+	})()
+	w.Wait()
 
 	if !writeJSONCalled {
 		t.Error("writeJSON call failed")
@@ -29,7 +93,13 @@ func Test_tickResponse_1call(t *testing.T) {
 	t.Log("Test tickResponse when sending one response")
 
 	s := *createServer(t)
+	s.transport.closeConnection = func(conn *websocket.Conn) error {
+		return nil
+	}
+
 	conn := &websocket.Conn{}
+	w := sync.WaitGroup{}
+	w.Add(1)
 	s.connections.Store(conn, make(chan *JSONRPCresponse))
 
 	var actualResponse JSONRPCresponse
@@ -39,34 +109,41 @@ func Test_tickResponse_1call(t *testing.T) {
 
 	s.transport.writeJSON = func(_ *websocket.Conn, response *JSONRPCresponse) error {
 		actualResponse = *response
+		w.Done()
 		return nil
 	}
 
 	go s.tickResponse(conn)
 	connChan, _ := s.connections.Load(conn)
 	connChan.(chan *JSONRPCresponse) <- &expectedResponse
-	connChan.(chan *JSONRPCresponse) <- nil
+	w.Wait()
 
 	if expectedResponse.Method != actualResponse.Method ||
 		expectedResponse.ID != actualResponse.ID {
 		t.Error("expectedResponse differs from actualResponse")
 	}
 
-	if <-s.tick {
-		t.Error("tick is open")
-	}
+	s.closeConnection(conn)
 }
 
-func Test_tickResponse_2call(t *testing.T) {
-	t.Log("Test tickResponse when sending two responses")
+func Test_tickResponse_3call(t *testing.T) {
+	t.Log("Test tickResponse when sending 3 responses")
 
 	s := *createServer(t)
+	s.transport.closeConnection = func(conn *websocket.Conn) error {
+		return nil
+	}
+
+	w := sync.WaitGroup{}
+	w.Add(3)
+
 	conn := &websocket.Conn{}
 	connChan := make(chan *JSONRPCresponse)
 	s.connections.Store(conn, connChan)
 
 	var actualResponse1 JSONRPCresponse
 	var actualResponse2 JSONRPCresponse
+	var actualResponse3 JSONRPCresponse
 	expectedResponse1 := JSONRPCresponse{}
 	expectedResponse1.Method = "method-1"
 	expectedResponse1.ID = "1"
@@ -74,6 +151,10 @@ func Test_tickResponse_2call(t *testing.T) {
 	expectedResponse2 := JSONRPCresponse{}
 	expectedResponse2.Method = "method-1"
 	expectedResponse2.ID = "2"
+
+	expectedResponse3 := JSONRPCresponse{}
+	expectedResponse3.Method = "method-1"
+	expectedResponse3.ID = "3"
 
 	s.transport.writeJSON = func(_ *websocket.Conn, response *JSONRPCresponse) error {
 		ID := (*response).ID
@@ -83,13 +164,18 @@ func Test_tickResponse_2call(t *testing.T) {
 		if ID == "2" {
 			actualResponse2 = *response
 		}
+		if ID == "3" {
+			actualResponse3 = *response
+		}
+		w.Done()
 		return nil
 	}
 
 	go s.tickResponse(conn)
 	connChan <- &expectedResponse1
 	connChan <- &expectedResponse2
-	connChan <- nil
+	connChan <- &expectedResponse3
+	w.Wait()
 
 	if expectedResponse1.Method != actualResponse1.Method ||
 		expectedResponse1.ID != actualResponse1.ID {
@@ -101,9 +187,12 @@ func Test_tickResponse_2call(t *testing.T) {
 		t.Error("expectedResponse2 differs from actualResponse2")
 	}
 
-	if <-s.tick {
-		t.Error("tick is open")
+	if expectedResponse3.Method != actualResponse3.Method ||
+		expectedResponse3.ID != actualResponse3.ID {
+		t.Error("expectedResponse3 differs from actualResponse3")
 	}
+
+	s.closeConnection(conn)
 }
 
 func Test_Broadcast(t *testing.T) {
@@ -152,8 +241,6 @@ func Test_Broadcast(t *testing.T) {
 		t.Error("expectedResponse differs from actualResponse2")
 	}
 
-	go (func() {
-		s.closeConnection(conn1)
-		s.closeConnection(conn2)
-	})()
+	s.closeConnection(conn1)
+	s.closeConnection(conn2)
 }

--- a/types.go
+++ b/types.go
@@ -40,8 +40,8 @@ type JSONRequestHandler func(
 	context *interface{},
 ) (interface{}, error)
 
-// JSONRPCServerWS whatever
-type JSONRPCServerWS struct {
+// JSONRPCExtensionWS whatever
+type JSONRPCExtensionWS struct {
 	connections sync.Map
 	tick        chan bool
 	handlers    map[string]map[string]*JSONRequestHandler


### PR DESCRIPTION
This is an attempt to fix the errors that were in the first version.
The main fix here is the way to execute `writeJSON` by using two calls to the channel `s.tick`